### PR TITLE
Fix header/menu stickiness

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -88,7 +88,7 @@ h4 {
 .site-header {
   padding: 1.4rem 0;
   position: sticky;
-  top: 6%;
+  top: 0;
   background: rgba(243, 240, 235, 0.96);
   backdrop-filter: blur(8px);
   z-index: 10;

--- a/planning-20260118.md
+++ b/planning-20260118.md
@@ -12,6 +12,10 @@ Source: `agentPrep-2026018` (prior agent notes).
 - Analytics: GA4 (free)
 - Speaking page: keep a placeholder "Coming soon" page until Emily confirms content
 
+## Issues
+
+- [x] Header/menu floats awkwardly because `.site-header` uses `position: sticky` with `top: 6%` instead of being pinned to the top.
+
 ## Current site map and content
 
 Core pages and content to rebuild:


### PR DESCRIPTION
## Summary
- align sticky header to top of viewport
- log header/menu float issue in planning notes

## Testing
- Not run (static site)