### PR TITLE
UI polish: skip link, nav, button shape

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,10 +11,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-404">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -32,7 +33,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container hero-grid">
         <div>
@@ -54,7 +55,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/about/index.html
+++ b/about/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-about">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero hero-banner" style="--hero-image: url('/emilyPottsCounseling/assets/img/about-hero.jpg');">
       <div class="container hero-inner">
         <div class="eyebrow">Counsellor | Speaker | Writer</div>
@@ -153,7 +154,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -11,6 +11,7 @@
   --max-width: 1100px;
   --content-gap: clamp(2rem, 4vw, 4.5rem);
   --radius: 18px;
+  --button-radius: 12px;
   --shadow: 0 18px 45px rgba(27, 28, 84, 0.12);
   --shadow-soft: 0 16px 40px rgba(63, 65, 60, 0.12);
 }
@@ -25,6 +26,32 @@ body {
   color: var(--text);
   background: var(--bg);
   line-height: 1.65;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.85rem;
+  left: 0.85rem;
+  padding: 0.75rem 1.1rem;
+  border-radius: var(--button-radius);
+  background: var(--dark);
+  color: #f7f6f4;
+  font-family: "Source Sans 3", "Helvetica Neue", Arial, sans-serif;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  transform: translateY(-220%);
+  transition: transform 180ms ease;
+  z-index: 20;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
+:focus-visible {
+  outline: 2px solid var(--dark);
+  outline-offset: 3px;
 }
 
 .sr-only {
@@ -138,6 +165,23 @@ h4 {
   color: var(--text);
 }
 
+.site-nav a[aria-current="page"] {
+  color: var(--dark);
+  position: relative;
+}
+
+.site-nav a[aria-current="page"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.35rem;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  opacity: 0.9;
+}
+
 .site-nav-links {
   display: flex;
   align-items: center;
@@ -147,7 +191,7 @@ h4 {
 
 .nav-cta {
   padding: 0.7rem 1.5rem;
-  border-radius: 999px 999px 22px 22px;
+  border-radius: var(--button-radius);
   border: 1px solid rgba(115, 118, 160, 0.6);
   color: #6d6f8e;
   font-size: 0.8rem;
@@ -169,6 +213,7 @@ h4 {
   letter-spacing: 0.2em;
   text-transform: uppercase;
   padding: 0.5rem 0.8rem;
+  border-radius: var(--button-radius);
 }
 
 .hero {
@@ -553,7 +598,7 @@ h4 {
   align-items: center;
   gap: 0.5rem;
   padding: 0.85rem 1.6rem;
-  border-radius: 999px 999px 22px 22px;
+  border-radius: var(--button-radius);
   font-family: "Source Sans 3", "Helvetica Neue", Arial, sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -911,21 +956,56 @@ footer a {
 }
 
 @media (max-width: 860px) {
+  body.nav-open {
+    overflow: hidden;
+  }
+
+  body.nav-open::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: rgba(27, 28, 84, 0.35);
+    z-index: 8;
+  }
+
   .site-nav {
     display: none;
     flex-direction: column;
     align-items: flex-start;
-    width: 100%;
-    padding: 1rem 0;
-    border-top: 1px solid rgba(63, 65, 60, 0.15);
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    padding: 7rem 1.5rem 2.5rem;
+    background: rgba(243, 240, 235, 0.98);
+    backdrop-filter: blur(12px);
+    border-top: none;
+    overflow-y: auto;
+    z-index: 9;
   }
 
   .site-nav[data-open="true"] {
     display: flex;
   }
 
+  .site-nav-links {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    gap: 1.2rem;
+    margin: 0;
+  }
+
+  .site-nav a {
+    font-size: 1.1rem;
+  }
+
+  .nav-cta {
+    margin-top: 1.25rem;
+  }
+
   .nav-toggle {
     display: inline-flex;
+    z-index: 10;
   }
 
   .site-header .container {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,10 +1,88 @@
 const toggle = document.querySelector(".nav-toggle");
 const nav = document.querySelector(".site-nav");
 
+const normalizePath = (path) => {
+  if (!path) return "/";
+  const withoutIndex = path.replace(/index\.html$/i, "");
+  const trimmed = withoutIndex.endsWith("/") ? withoutIndex.slice(0, -1) : withoutIndex;
+  return trimmed.length ? trimmed : "/";
+};
+
+const markCurrentNavLink = () => {
+  const navLinks = Array.from(document.querySelectorAll(".site-nav-links a[href]"));
+  const currentPath = normalizePath(window.location.pathname);
+
+  const candidates = navLinks
+    .map((link) => {
+      try {
+        const url = new URL(link.getAttribute("href"), window.location.origin);
+        if (url.origin !== window.location.origin) return null;
+        return { link, path: normalizePath(url.pathname) };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  let bestMatch = null;
+  for (const candidate of candidates) {
+    candidate.link.removeAttribute("aria-current");
+
+    if (candidate.path === "/" || candidate.path === currentPath) {
+      bestMatch = bestMatch && bestMatch.path.length > candidate.path.length ? bestMatch : candidate;
+      continue;
+    }
+
+    if (currentPath.startsWith(`${candidate.path}/`)) {
+      bestMatch = bestMatch && bestMatch.path.length > candidate.path.length ? bestMatch : candidate;
+    }
+  }
+
+  if (bestMatch) {
+    bestMatch.link.setAttribute("aria-current", "page");
+  }
+};
+
+markCurrentNavLink();
+
 if (toggle && nav) {
+  const setNavOpen = (nextOpen, options = {}) => {
+    nav.setAttribute("data-open", String(nextOpen));
+    toggle.setAttribute("aria-expanded", String(nextOpen));
+    toggle.textContent = nextOpen ? "Close Menu" : "Open Menu";
+    document.body.classList.toggle("nav-open", nextOpen);
+
+    if (nextOpen && options.focusFirstLink) {
+      const firstLink = nav.querySelector("a[href]");
+      firstLink?.focus();
+    }
+  };
+
+  const isOpen = nav.getAttribute("data-open") === "true";
+  setNavOpen(isOpen);
+
   toggle.addEventListener("click", () => {
-    const isOpen = nav.getAttribute("data-open") === "true";
-    nav.setAttribute("data-open", String(!isOpen));
-    toggle.setAttribute("aria-expanded", String(!isOpen));
+    const currentlyOpen = nav.getAttribute("data-open") === "true";
+    setNavOpen(!currentlyOpen, { focusFirstLink: !currentlyOpen });
+  });
+
+  nav.addEventListener("click", (event) => {
+    const link = event.target.closest?.("a[href]");
+    if (link) {
+      setNavOpen(false);
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") return;
+    if (nav.getAttribute("data-open") !== "true") return;
+    setNavOpen(false);
+    toggle.focus();
+  });
+
+  document.addEventListener("click", (event) => {
+    if (nav.getAttribute("data-open") !== "true") return;
+    if (nav.contains(event.target) || toggle.contains(event.target)) return;
+    setNavOpen(false);
   });
 }

--- a/contact/index.html
+++ b/contact/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-contact">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero hero-banner" style="--hero-image: url('/emilyPottsCounseling/assets/img/contact-hero.jpg');">
       <div class="container hero-inner">
         <div class="eyebrow">Counselling | Speaking | Workshops</div>
@@ -107,7 +108,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/faqs/index.html
+++ b/faqs/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-faqs">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero hero-banner" style="--hero-image: url('/emilyPottsCounseling/assets/img/faqs-hero.jpg');">
       <div class="container">
         <h1>Frequently Asked Questions</h1>
@@ -103,7 +104,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/index.html
+++ b/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-home">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero hero-split">
       <div class="hero-split-grid">
         <div class="hero-image-panel">
@@ -155,7 +156,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/privacy-page/index.html
+++ b/privacy-page/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-privacy">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container">
         <h1>Privacy Policy</h1>
@@ -62,7 +63,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/resources/Blog Post Title One-y2epy-y63ns/index.html
+++ b/resources/Blog Post Title One-y2epy-y63ns/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-resource">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container">
         <div class="blog-meta">Emily Potts · 2024-07-17</div>
@@ -82,7 +83,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/resources/exploring-solutions-for-climate-anxiety/index.html
+++ b/resources/exploring-solutions-for-climate-anxiety/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-resource">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container">
         <div class="blog-meta">Emily Potts · 2024-07-03</div>
@@ -77,7 +78,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/resources/index.html
+++ b/resources/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-resources">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container">
         <h1>Resources</h1>
@@ -81,7 +82,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/services-and-fees/index.html
+++ b/services-and-fees/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-services">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero hero-banner" style="--hero-image: url('/emilyPottsCounseling/assets/img/services-hero.jpg');">
       <div class="container hero-inner">
         <div class="eyebrow">In-person and virtual counselling services</div>
@@ -198,7 +199,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/speaking/index.html
+++ b/speaking/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-speaking">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container">
         <h1>Speaking</h1>
@@ -59,7 +60,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>

--- a/therapy/index.html
+++ b/therapy/index.html
@@ -24,10 +24,11 @@
   <link rel="stylesheet" href="/emilyPottsCounseling/assets/css/styles.css">
 </head>
 <body class="page-therapy">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="container">
       <a class="site-title" href="/emilyPottsCounseling/">
-        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling">
+        <img class="site-logo" src="/emilyPottsCounseling/assets/img/logo-sad-girl.png" alt="Emily Potts Counselling" width="46" height="46">
         <span class="site-name sr-only">Emily Potts Counselling</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -45,7 +46,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     <section class="hero">
       <div class="container">
         <h1>Therapy approaches</h1>
@@ -104,7 +105,7 @@
   <footer>
     <div class="container">
       <div class="footer-logo">
-        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling">
+        <img src="/emilyPottsCounseling/assets/img/logo-sad-girl-white.png" alt="Emily Potts Counselling" width="72" height="72" loading="lazy">
       </div>
       <div class="footer-grid">
         <div>


### PR DESCRIPTION
## Summary
- Add skip link + improved focus styles across pages
- Improve mobile nav (overlay, Open/Close label, close on Esc/outside click)
- Highlight current page in the header nav via `aria-current="page"`
- Make buttons less pointy by standardizing border radius across `.btn`, `.nav-cta`, and `.nav-toggle`
- Reduce minor CLS for logos (explicit dimensions + lazy-load footer logo)

## Verification
- Reviewed locally with `agent-browser` (desktop + mobile menu open/close, Esc-to-close, `aria-current` on section pages)

Refs #49
